### PR TITLE
Various modernization and flexibility enhancements

### DIFF
--- a/jquery.tilezoom.css
+++ b/jquery.tilezoom.css
@@ -1,5 +1,4 @@
 div.zoom-container {
-	position: relative;
 	overflow: hidden;
 }
 .zoom-container.zoom-full {

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -306,14 +306,14 @@ function getScale(level, settings) {
 
 function getTiles(level, settings) {
 	var cells = getNumTiles(level, settings);
-	var yield = [];
+	var array = [];
 	
 	for (row=0;row<=(cells.rows-1);row++) {
 		for (column=0;column<=(cells.columns-1);column++) {
-			 yield.push(new Array(column,row));
+			 array.push(new Array(column,row));
 		}
 	}
-	return yield;
+	return array;
 }
 
 function getNumTiles(level, settings) {

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -34,6 +34,8 @@ var methods = {
 			zoomToCursor: true, // stay the same relative distance from the edge when zooming
 			offset: '20%', //boundaries offset (px or %). If 0 image move side to side and up to down
 			dragBoundaries: true, // If we should constrain the drag to the boundaries
+			minZoomLevel: 0, // can't zoom out past level [minZoom]
+			maxZoomLevel: 9999, // can't zoom in past level [maxZoom]
 			wrapZoom: true, // If we're at the high level of resolution, go back to the start level
 			beforeZoom: function($cont) {}, // callback before a zoom happens
 			onZoom: function($cont, progress) {}, // callback for each zoom animation step
@@ -90,7 +92,8 @@ var methods = {
 			var settings = $cont.data('tilezoom.settings');
 			if(settings.inAction) return false;
 			
-			if(9 <= level && level < settings.numLevels && level != settings.level) {
+			if (level >= 9 && level >= settings.minZoomLevel && level <= settings.maxZoomLevel &&
+				level < settings.numLevels && level != settings.level) {
 				//beforeZoom callback
 				if(typeof settings.beforeZoom == "function") {
 					settings.beforeZoom($cont);

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -522,11 +522,9 @@ function initGestures($cont) {
 	    manager.add(new Hammer.Pan({ direction: Hammer.DIRECTION_ALL }));
 		
 	    manager.on("panstart", function () {
-	        console.log("panstart");
 		    if (settings.inAction) return false;
 			$holder.stop(true, true);
 			dragging = true;
-			pos = {};
 			startLeft = parseInt($holder.css('left'));
 			startTop = parseInt($holder.css('top'));
 			startLevel = settings.level;
@@ -536,8 +534,8 @@ function initGestures($cont) {
 		});
 
 	    manager.on("panmove", function (ev) {
-	        console.log("panmove");
-		    if (!dragging) return;
+	        if (!dragging) return;
+	        if (!pos) pos = {};
 			pos.left = startLeft + ev.deltaX;
 			pos.top = startTop + ev.deltaY;
 			if (settings.dragBoundaries) {
@@ -547,7 +545,7 @@ function initGestures($cont) {
 		});
 
 	    manager.on("panend", function () {
-	        console.log("panend");
+	        if (!pos) return;
 		    dragging = false;
 			checkTiles($cont);
 			//callAfter callback
@@ -562,8 +560,6 @@ function initGestures($cont) {
 			var level = (scale > 1) ?
 				startLevel + Math.floor(scale) :
 				startLevel - Math.floor(1 / scale);
-			console.log("pinch level before : " + startLevel);
-			console.log("pinch level after : " + level);
 			$cont.tilezoom('zoom', level, {});
 		});
 	}

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -513,7 +513,7 @@ function initGestures($cont) {
 		var dragging = false;
 		var startLeft = 0;
 		var startTop = 0;
-		var startLevel;
+		var startLevel = settings.level;
 		var pos;
 
 		var manager = new Hammer.Manager($holder[0], { preventDefault: true });
@@ -521,7 +521,8 @@ function initGestures($cont) {
 	    manager.add(new Hammer.Pinch({ threshold: 0.1 }));
 	    manager.add(new Hammer.Pan({ direction: Hammer.DIRECTION_ALL }));
 		
-		manager.on("panstart", function () {
+	    manager.on("panstart", function () {
+	        console.log("panstart");
 		    if (settings.inAction) return false;
 			$holder.stop(true, true);
 			dragging = true;
@@ -534,7 +535,8 @@ function initGestures($cont) {
 			}
 		});
 
-		manager.on("panmove", function (ev) {
+	    manager.on("panmove", function (ev) {
+	        console.log("panmove");
 		    if (!dragging) return;
 			pos.left = startLeft + ev.deltaX;
 			pos.top = startTop + ev.deltaY;
@@ -544,7 +546,8 @@ function initGestures($cont) {
 			$holder.css({ 'left': pos.left, 'top': pos.top });
 		});
 
-		manager.on("panend", function () {
+	    manager.on("panend", function () {
+	        console.log("panend");
 		    dragging = false;
 			checkTiles($cont);
 			//callAfter callback
@@ -559,6 +562,8 @@ function initGestures($cont) {
 			var level = (scale > 1) ?
 				startLevel + Math.floor(scale) :
 				startLevel - Math.floor(1 / scale);
+			console.log("pinch level before : " + startLevel);
+			console.log("pinch level after : " + level);
 			$cont.tilezoom('zoom', level, {});
 		});
 	}

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -27,7 +27,8 @@ var methods = {
 	        overlap: 1, // tiles overlap
 	        thumb: 'thumb.jpg', // thumbnail filename
 	        format: 'jpg', // image format
-	        speed: 500, //animation speed (ms)
+	        speed: 500, // animation speed (ms)
+            easing: 'swing', // animation easing (jquery easing function name)
 	        mousewheel: false, // requires mousewheel event plugin: http://plugins.jquery.com/project/mousewheel
 	        gestures: false, // requires hammer.js event plugin, https://github.com/hammerjs/hammer.js
 	        zoomToCursor: true, // stay the same relative distance from the edge when zooming
@@ -760,8 +761,6 @@ function setSizePosition($cont, coords ,speed, callback) {
 	$tiles.hide();
 	$tiles.css(styles);
 
-	var easing = "swing";
-
     $holder.stop(true,true).animate({
 		'width': levelImage.width,
 		'height': levelImage.height,
@@ -769,14 +768,14 @@ function setSizePosition($cont, coords ,speed, callback) {
 		'top': pos.top
 	}, {
 	    duration: speed,
-	    easing: easing,
+	    easing: settings.easing,
         progress: function(animation, progress) {
             settings.onZoom($cont, progress);
         }
 	});
 	
-	$hotspots.stop(true,true).animate(styles, speed, easing);
-	$thumb.stop(true,true).animate(styles, speed, easing, function() {
+    $hotspots.stop(true, true).animate(styles, speed, settings.easing);
+    $thumb.stop(true, true).animate(styles, speed, settings.easing, function () {
 		$tiles.fadeIn(speed);
 		if (typeof callback == "function") callback();
 		settings.inAction = false;

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -41,7 +41,7 @@ var methods = {
 			callBefore: function($cont) {}, // this callback happens before dragging starts
 			callAfter: function($cont, coords) {}, // this callback happens at end of drag after released "mouseup"
 			initialized: function($cont) {}, // this callback happens after tilezoom  has been fully initalized.
-			navigation: true, // navigation container ([true], [false], [DOM selector])
+			navigation: true, // navigation container ([true: show nav controls] or [false: don't show nav controls] or [DOM selector to insert controls in])
 			zoomIn: null, // zoomIn button
 			zoomOut: null, // zoomOut button
 			goHome: null, // goHome button, reset to default state

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -159,12 +159,9 @@ function initTilezoom(defaults, options, $cont, index) {
 	setSizePosition($cont, coords={}, 0, function() {
 		checkTiles($cont);
 		var isTouchSupported = (typeof(window.ontouchstart) != 'undefined');
-		if (isTouchSupported){
-			initGestures($cont);
-		} else {
-			initDraggable($cont);
-			initMousewheel($cont);
-		}	
+		if (isTouchSupported) initGestures($cont);
+		initDraggable($cont);
+		initMousewheel($cont);
 	});
 }
 

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -18,23 +18,23 @@ function log() {
 }
 var methods = {
 	init : function( options ) {
-	    var defaults = {
-	        width: null, // original image width in pixels. *(required) if no xml file
-	        height: null, // original image height in pixels *(required) if no xml file
-	        path: null, // tiles directory. *(required) if no xml file
-	        xml: null, // xml file with settings generated with Deep Zoom Tools
-	        tileSize: 254, // tile size in pixels
-	        overlap: 1, // tiles overlap
-	        thumb: 'thumb.jpg', // thumbnail filename
-	        format: 'jpg', // image format
-	        speed: 500, // animation speed (ms)
-            easing: 'swing', // animation easing (jquery easing function name)
-	        mousewheel: false, // requires mousewheel event plugin: http://plugins.jquery.com/project/mousewheel
-	        gestures: false, // requires hammer.js event plugin, https://github.com/hammerjs/hammer.js
-	        zoomToCursor: true, // stay the same relative distance from the edge when zooming
-	        offset: '20%', //boundaries offset (px or %). If 0 image move side to side and up to down
-	        dragBoundaries: true, // If we should constrain the drag to the boundaries
-	        wrapZoom: true, // If we're at the high level of resolution, go back to the start level
+		var defaults = {
+			width: null, // original image width in pixels. *(required) if no xml file
+			height: null, // original image height in pixels *(required) if no xml file
+			path: null, // tiles directory. *(required) if no xml file
+			xml: null, // xml file with settings generated with Deep Zoom Tools
+			tileSize: 254, // tile size in pixels
+			overlap: 1, // tiles overlap
+			thumb: 'thumb.jpg', // thumbnail filename
+			format: 'jpg', // image format
+			speed: 500, // animation speed (ms)
+			easing: 'swing', // animation easing (jquery easing function name)
+			mousewheel: false, // requires mousewheel event plugin: http://plugins.jquery.com/project/mousewheel
+			gestures: false, // requires hammer.js event plugin, https://github.com/hammerjs/hammer.js
+			zoomToCursor: true, // stay the same relative distance from the edge when zooming
+			offset: '20%', //boundaries offset (px or %). If 0 image move side to side and up to down
+			dragBoundaries: true, // If we should constrain the drag to the boundaries
+			wrapZoom: true, // If we're at the high level of resolution, go back to the start level
 			beforeZoom: function($cont) {}, // callback before a zoom happens
 			onZoom: function($cont, progress) {}, // callback for each zoom animation step
 			afterZoom: function($cont) {}, // callback after zoom has completed
@@ -268,11 +268,11 @@ function initTiles($cont, level) {
 	$.each(tiles, function(index, tile) {
 		var src = levelDir+'/'+tile[0]+'_'+tile[1]+'.'+settings.format;
 		var offsetX = tile[0] == 0 ? 0 : settings.overlap;
-       	var offsetY = tile[1] == 0 ? 0 : settings.overlap;
+		var offsetY = tile[1] == 0 ? 0 : settings.overlap;
 		var id = 'zoom-'+settings.id+'-tile-'+tile[0]+'-'+tile[1];
 		var style = 'position: absolute; left: '+(tile[0]*settings.tileSize-offsetX)+'px; top: '+(tile[1]*settings.tileSize-offsetY)+'px; z-index: 0;';
 		$('<img/>', {
-		    _src: src,
+			_src: src,
 			id: id,
 			style: style
 		}).appendTo($tiles);
@@ -324,7 +324,7 @@ function getNumTiles(level, settings) {
 		var dimension = getDimension(level, settings);
 		var cells = {};
 		cells.columns = parseInt(Math.ceil(parseFloat(dimension.width) / settings.tileSize));
-  		cells.rows = parseInt(Math.ceil(parseFloat(dimension.height) / settings.tileSize));
+		cells.rows = parseInt(Math.ceil(parseFloat(dimension.height) / settings.tileSize));
 		return cells;
 	}
 	else {
@@ -376,15 +376,15 @@ function getVisibleTiles($cont) {
  */
 
 function onDoubleTap($cont, coords) {
-    var settings = $cont.data('tilezoom.settings');
-    var level = settings.level;
-    if (settings.level < settings.numLevels - 1) {
-        level = settings.level + 1;
-    } else if (settings.wrapZoom) {
-        // If we're at the high level of resolution, go back to the start level
-        level = settings.startLevel;
-    }
-    $cont.tilezoom('zoom', level, coords);
+	var settings = $cont.data('tilezoom.settings');
+	var level = settings.level;
+	if (settings.level < settings.numLevels - 1) {
+		level = settings.level + 1;
+	} else if (settings.wrapZoom) {
+		// If we're at the high level of resolution, go back to the start level
+		level = settings.startLevel;
+	}
+	$cont.tilezoom('zoom', level, coords);
 }
 
 /*
@@ -408,11 +408,11 @@ function initDraggable($cont) {
 		var coords = {};
 		coords.x = e.pageX;
 		coords.y = e.pageY;
-	    onDoubleTap($cont, coords);
+		onDoubleTap($cont, coords);
 	});
 	
 	$holder.mousedown(function(e) {
-	    if(settings.gesturing) return false;
+		if(settings.gesturing) return false;
 		if(settings.inAction) return false;
 		$holder.stop(true,true);
 		$hotspots.removeClass('grab').addClass('grabbing');
@@ -424,8 +424,8 @@ function initDraggable($cont) {
 		var pos = {};	
 		//callBefore callback
 		if(typeof settings.callBefore == "function") {
-            settings.callBefore($cont);
-        }
+			settings.callBefore($cont);
+		}
 		$(document).unbind("mousemove");
 		$(document).mousemove(function (e) {
 			if(dragging){
@@ -447,8 +447,8 @@ function initDraggable($cont) {
 			checkTiles($cont);
 			//callAfter callback
 			if(typeof settings.callAfter == "function") {
-	            settings.callAfter($cont, {'startLeft':startLeft, 'startTop':startTop, 'endLeft':pos.left, 'endTop':pos.top});
-	        }
+				settings.callAfter($cont, {'startLeft':startLeft, 'startTop':startTop, 'endLeft':pos.left, 'endTop':pos.top});
+			}
 		});
 		return false;
 	});
@@ -521,7 +521,7 @@ function initGestures($cont) {
 	var settings = $cont.data('tilezoom.settings');
 	var $holder = settings.holder;
 
-    if(settings.gestures && typeof Hammer != "undefined") {
+	if(settings.gestures && typeof Hammer != "undefined") {
 		// gestures don't affect inside the container
 		$cont.bind('touchmove', function(e){
 			e.preventDefault();
@@ -540,52 +540,52 @@ function initGestures($cont) {
 		hammertime.get("pan").set({ direction: Hammer.DIRECTION_ALL });
 		
 		hammertime.on("panstart", function () {
-		    if (settings.inAction) return false;
-		    settings.gesturing = true;
-		    $holder.stop(true, true);
-		    dragging = true;
-		    pos = {};
-		    startLeft = parseInt($holder.css('left'));
-		    startTop = parseInt($holder.css('top'));
-		    startLevel = settings.level;
-		    if (typeof settings.callBefore == "function") {
-		        settings.callBefore($cont);
-		    }
+			if (settings.inAction) return false;
+			settings.gesturing = true;
+			$holder.stop(true, true);
+			dragging = true;
+			pos = {};
+			startLeft = parseInt($holder.css('left'));
+			startTop = parseInt($holder.css('top'));
+			startLevel = settings.level;
+			if (typeof settings.callBefore == "function") {
+				settings.callBefore($cont);
+			}
 		});
 
 		hammertime.on("panmove", function (ev) {
-		    if (!dragging) return;
-		    pos.left = startLeft + ev.deltaX;
-		    pos.top = startTop + ev.deltaY;
-		    if (settings.dragBoundaries) {
-		        checkBoundaries($cont, pos);
-		    }
-		    $holder.css({ 'left': pos.left, 'top': pos.top });
-        });
+			if (!dragging) return;
+			pos.left = startLeft + ev.deltaX;
+			pos.top = startTop + ev.deltaY;
+			if (settings.dragBoundaries) {
+				checkBoundaries($cont, pos);
+			}
+			$holder.css({ 'left': pos.left, 'top': pos.top });
+		});
 
 		hammertime.on("panend", function () {
-		    dragging = false;
-		    settings.gesturing = false;
-		    checkTiles($cont);
-		    //callAfter callback
-		    if (typeof settings.callAfter == "function") {
-		        settings.callAfter($cont, { 'startLeft': startLeft, 'startTop': startTop, 'endLeft': pos.left, 'endTop': pos.top });
-		    }
-        });
+			dragging = false;
+			settings.gesturing = false;
+			checkTiles($cont);
+			//callAfter callback
+			if (typeof settings.callAfter == "function") {
+				settings.callAfter($cont, { 'startLeft': startLeft, 'startTop': startTop, 'endLeft': pos.left, 'endTop': pos.top });
+			}
+		});
 
 		hammertime.on("pinch", function (ev) {
-		    dragging = false;
-		    var scale = ev.scale;
-		    var level = (scale > 1) ?
-                startLevel + Math.floor(scale) :
-                startLevel - Math.floor(1 / scale);
-		    $cont.tilezoom('zoom', level, {});
+			dragging = false;
+			var scale = ev.scale;
+			var level = (scale > 1) ?
+				startLevel + Math.floor(scale) :
+				startLevel - Math.floor(1 / scale);
+			$cont.tilezoom('zoom', level, {});
 		});
 
 		hammertime.on("tap", function (ev) {
-		    coords.x = ev.center.x + ev.deltaX;
-		    coords.y = ev.center.y + ev.deltaY;
-		    onDoubleTap($cont, coords);
+			coords.x = ev.center.x + ev.deltaX;
+			coords.y = ev.center.y + ev.deltaY;
+			onDoubleTap($cont, coords);
 		});
 	}
 }
@@ -761,21 +761,21 @@ function setSizePosition($cont, coords ,speed, callback) {
 	$tiles.hide();
 	$tiles.css(styles);
 
-    $holder.stop(true,true).animate({
+	$holder.stop(true,true).animate({
 		'width': levelImage.width,
 		'height': levelImage.height,
 		'left': pos.left,
 		'top': pos.top
 	}, {
-	    duration: speed,
-	    easing: settings.easing,
-        progress: function(animation, progress) {
-            settings.onZoom($cont, progress);
-        }
+		duration: speed,
+		easing: settings.easing,
+		progress: function(animation, progress) {
+			settings.onZoom($cont, progress);
+		}
 	});
 	
-    $hotspots.stop(true, true).animate(styles, speed, settings.easing);
-    $thumb.stop(true, true).animate(styles, speed, settings.easing, function () {
+	$hotspots.stop(true, true).animate(styles, speed, settings.easing);
+	$thumb.stop(true, true).animate(styles, speed, settings.easing, function () {
 		$tiles.fadeIn(speed);
 		if (typeof callback == "function") callback();
 		settings.inAction = false;

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -397,6 +397,7 @@ function initDraggable($cont) {
 	});
 	
 	$holder.mousedown(function(e) {
+	    if(settings.gesturing) return false;
 		if(settings.inAction) return false;
 		$holder.stop(true,true);
 		$hotspots.removeClass('grab').addClass('grabbing');
@@ -411,7 +412,7 @@ function initDraggable($cont) {
             settings.callBefore($cont);
         }
 		$(document).unbind("mousemove");
-		$(document).mousemove(function(e) {
+		$(document).mousemove(function (e) {
 			if(dragging){
 				var offsetX =  e.pageX - startX;
 				var offsetY =  e.pageY - startY;
@@ -424,7 +425,7 @@ function initDraggable($cont) {
 			}
 		});
 		
-		$(document).one('mouseup', function() {
+		$(document).one('mouseup', function () {
 			$(document).unbind("mousemove");
 			$hotspots.removeClass('grabbing').addClass('grab');		
 			dragging = false;
@@ -523,8 +524,9 @@ function initGestures($cont) {
 		var pos;
 		
 		$holder.touchit({
-			onTouchStart: function (x, y) {
-				if(settings.inAction) return false;
+		    onTouchStart: function (x, y) {
+		        if(settings.inAction) return false;
+		        settings.gesturing = true;
 				$holder.stop(true,true);
 				dragging = true;
 				pos = {};
@@ -551,6 +553,7 @@ function initGestures($cont) {
 			},
 			onTouchEnd: function (x, y) {
 				dragging = false;
+				settings.gesturing = false;
 				checkTiles($cont);
 				//callAfter callback
 				if(typeof settings.callAfter == "function") {

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -18,21 +18,22 @@ function log() {
 }
 var methods = {
 	init : function( options ) {
-		var defaults = {
-			width: null, // original image width in pixels. *(required) if no xml file
-			height: null, // original image height in pixels *(required) if no xml file
-			path: null, // tiles directory. *(required) if no xml file
-			xml: null, // xml file with settings generated with Deep Zoom Tools
-			tileSize: 254, // tile size in pixels
-			overlap: 1, // tiles overlap
-			thumb: 'thumb.jpg', // thumbnail filename
-			format: 'jpg', // image format
-			speed: 500, //animation speed (ms)
-			mousewheel: false, // requires mousewheel event plugin: http://plugins.jquery.com/project/mousewheel
-			gestures: false, // requires touchit event plugin, https://github.com/danielglyde/TouchIt
-			zoomToCursor: true, // stay the same relative distance from the edge when zooming
-			offset: '20%', //boundaries offset (px or %). If 0 image move side to side and up to down
-			dragBoundaries: true, // If we should constrain the drag to the boundaries
+	    var defaults = {
+	        width: null, // original image width in pixels. *(required) if no xml file
+	        height: null, // original image height in pixels *(required) if no xml file
+	        path: null, // tiles directory. *(required) if no xml file
+	        xml: null, // xml file with settings generated with Deep Zoom Tools
+	        tileSize: 254, // tile size in pixels
+	        overlap: 1, // tiles overlap
+	        thumb: 'thumb.jpg', // thumbnail filename
+	        format: 'jpg', // image format
+	        speed: 500, //animation speed (ms)
+	        mousewheel: false, // requires mousewheel event plugin: http://plugins.jquery.com/project/mousewheel
+	        gestures: false, // requires hammer.js event plugin, https://github.com/hammerjs/hammer.js
+	        zoomToCursor: true, // stay the same relative distance from the edge when zooming
+	        offset: '20%', //boundaries offset (px or %). If 0 image move side to side and up to down
+	        dragBoundaries: true, // If we should constrain the drag to the boundaries
+	        wrapZoom: true, // If we're at the high level of resolution, go back to the start level
 			beforeZoom: function($cont) {}, // callback before a zoom happens
 			afterZoom: function($cont) {}, // callback after zoom has completed
 			callBefore: function($cont) {}, // this callback happens before dragging starts
@@ -369,6 +370,22 @@ function getVisibleTiles($cont) {
 }
 
 /*
+ * Interaction
+ */
+
+function onDoubleTap($cont, coords) {
+    var settings = $cont.data('tilezoom.settings');
+    var level = settings.level;
+    if (settings.level < settings.numLevels - 1) {
+        level = settings.level + 1;
+    } else if (settings.wrapZoom) {
+        // If we're at the high level of resolution, go back to the start level
+        level = settings.startLevel;
+    }
+    $cont.tilezoom('zoom', level, coords);
+}
+
+/*
 * Init Draggable funtionality
 */
 
@@ -388,11 +405,8 @@ function initDraggable($cont) {
 	$holder.dblclick(function(e) {
 		var coords = {};
 		coords.x = e.pageX;
-		coords.y = e.pageY;		
-		// If we're at the high level of resolution, go back to the start level
-		var level = (settings.level < settings.numLevels - 1) ? 
-			settings.level+1 : settings.startLevel;
-		$cont.tilezoom('zoom', level, coords);
+		coords.y = e.pageY;
+	    onDoubleTap($cont, coords);
 	});
 	
 	$holder.mousedown(function(e) {
@@ -443,7 +457,6 @@ function initDraggable($cont) {
 */
 function initMousewheel($cont) {
 	var settings = $cont.data('tilezoom.settings');
-	var $holder = settings.holder;
 	
 	if(settings.mousewheel && typeof $.fn.mousewheel != "undefined") {
 		$cont.unbind('mousewheel');
@@ -570,21 +583,8 @@ function initGestures($cont) {
 		hammertime.on("tap", function (ev) {
 		    coords.x = ev.center.x + ev.deltaX;
 		    coords.y = ev.center.y + ev.deltaY;
-		    // If we're at the high level of resolution, go back to the start level
-		    var level = (settings.level < settings.numLevels - 1) ?
-		        settings.level + 1 : settings.startLevel;
-		    $cont.tilezoom('zoom', level, coords);
+		    onDoubleTap($cont, coords);
 		});
-
-        // TODO: ON DOUBLE TAP:
-
-		//var coords = {};
-		//coords.x = x;
-		//coords.y = y;
-        //// If we're at the high level of resolution, go back to the start level
-		//var level = (settings.level < settings.numLevels - 1) ?
-        //    settings.level + 1 : settings.startLevel;
-		//$cont.tilezoom('zoom', level, coords);
 	}
 }
 

--- a/jquery.tilezoom.js
+++ b/jquery.tilezoom.js
@@ -35,6 +35,7 @@ var methods = {
 	        dragBoundaries: true, // If we should constrain the drag to the boundaries
 	        wrapZoom: true, // If we're at the high level of resolution, go back to the start level
 			beforeZoom: function($cont) {}, // callback before a zoom happens
+			onZoom: function($cont, progress) {}, // callback for each zoom animation step
 			afterZoom: function($cont) {}, // callback after zoom has completed
 			callBefore: function($cont) {}, // this callback happens before dragging starts
 			callAfter: function($cont, coords) {}, // this callback happens at end of drag after released "mouseup"
@@ -758,16 +759,24 @@ function setSizePosition($cont, coords ,speed, callback) {
 	//apply styles
 	$tiles.hide();
 	$tiles.css(styles);
-	
-	$holder.stop(true,true).animate({
-		'width':levelImage.width,
-		'height':levelImage.height,
+
+	var easing = "swing";
+
+    $holder.stop(true,true).animate({
+		'width': levelImage.width,
+		'height': levelImage.height,
 		'left': pos.left,
 		'top': pos.top
-	}, speed, "swing");
+	}, {
+	    duration: speed,
+	    easing: easing,
+        progress: function(animation, progress) {
+            settings.onZoom($cont, progress);
+        }
+	});
 	
-	$hotspots.stop(true,true).animate(styles, speed, "swing");
-	$thumb.stop(true,true).animate(styles, speed, "swing", function() {
+	$hotspots.stop(true,true).animate(styles, speed, easing);
+	$thumb.stop(true,true).animate(styles, speed, easing, function() {
 		$tiles.fadeIn(speed);
 		if (typeof callback == "function") callback();
 		settings.inAction = false;


### PR DESCRIPTION
Here are some generic enhancements to tilezoom that we had to implement for our use case. They could be useful to any current emtasakov/tilezoom users.

**Noteworthy changes include:**

- Mouse input is not disabled when a touchscreen is detected (mouse input didn't work with Windows devices with seldom-used touchscreens).
- Using Hammer.js for more robust multi-touch input instead of dnaielglyde/TouchIt
- Added onZoom callback (called for each zoom step)
- Removed dependency on ES6 feature (yield, which didn't bring much to the table anyway).

The only thing I'm not totally confident about is commit d638f49. It fixed layout issues in our app and didn't seem to cause any problem with tilezoom, but maybe there was a reason for relative display to be enforced that I didn't consider?